### PR TITLE
feat: implement win condition (closes #18)

### DIFF
--- a/Assets/Scripts/Managers/GameStateManager.cs
+++ b/Assets/Scripts/Managers/GameStateManager.cs
@@ -1,8 +1,44 @@
 using UnityEngine;
 using TMPro;
 using UnityEngine.UI;
+using System.Collections.Generic;
 
 public class GameStateManager : MonoBehaviour
 {
-    // Implement Game State Manager logic here. This is for game logic functions to manage the active game (i.e startnewgame, checkwin, etc.).
+    private Dictionary<int, PuzzleGroup> _groups = new Dictionary<int, PuzzleGroup>();
+    private int _totalPieceCount;
+    private int _nextGroupId = 0;
+
+    public void StartNewGame(int totalPieces)
+    {
+        _totalPieceCount = totalPieces;
+        _groups.Clear();
+        _nextGroupId = 0;
+        for (int i = 0; i < totalPieces; i++)
+        {
+            var group = new PuzzleGroup(_nextGroupId++, i);
+            _groups[group.GroupId] = group;
+        }
+    }
+
+    public void OnPiecesConnected(int pieceIdA, int pieceIdB)
+    {
+        var groupA = FindGroupForPiece(pieceIdA);
+        var groupB = FindGroupForPiece(pieceIdB);
+        if (groupA == null || groupB == null || groupA.GroupId == groupB.GroupId)
+            return;
+        groupA.MergeFrom(groupB);
+        _groups.Remove(groupB.GroupId);
+        WinCondition.CheckWin(_groups, _totalPieceCount);
+    }
+
+    public int ActiveGroupCount() => _groups.Count;
+
+    private PuzzleGroup FindGroupForPiece(int pieceId)
+    {
+        foreach (var group in _groups.Values)
+            if (group.Contains(pieceId))
+                return group;
+        return null;
+    }
 }

--- a/Assets/Scripts/Puzzle/PuzzleGroup.cs
+++ b/Assets/Scripts/Puzzle/PuzzleGroup.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+public class PuzzleGroup
+{
+    public int GroupId { get; private set; }
+    private HashSet<int> _pieceIds = new HashSet<int>();
+
+    public IReadOnlyCollection<int> PieceIds => _pieceIds;
+    public int Count => _pieceIds.Count;
+
+    public PuzzleGroup(int groupId, int initialPieceId)
+    {
+        GroupId = groupId;
+        _pieceIds.Add(initialPieceId);
+    }
+
+    public void AddPiece(int pieceId) => _pieceIds.Add(pieceId);
+
+    public void MergeFrom(PuzzleGroup other)
+    {
+        foreach (var id in other._pieceIds)
+            _pieceIds.Add(id);
+    }
+
+    public bool Contains(int pieceId) => _pieceIds.Contains(pieceId);
+}

--- a/Assets/Scripts/Puzzle/WinCondition.cs
+++ b/Assets/Scripts/Puzzle/WinCondition.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+public static class WinCondition
+{
+    public static event Action OnPuzzleSolved;
+
+    public static bool CheckWin(Dictionary<int, PuzzleGroup> groups, int totalPieceCount)
+    {
+        if (groups == null || groups.Count != 1)
+            return false;
+
+        foreach (var group in groups.Values)
+        {
+            if (group.Count == totalPieceCount)
+            {
+                OnPuzzleSolved?.Invoke();
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Assets/Tests/EditMode/PuzzleGen.Tests.EditMode.asmdef
+++ b/Assets/Tests/EditMode/PuzzleGen.Tests.EditMode.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "PuzzleGen.Tests.EditMode",
+    "references": [],
+    "includePlatforms": ["Editor"],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": ["nunit.framework.dll"],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/EditMode/WinConditionTests.cs
+++ b/Assets/Tests/EditMode/WinConditionTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+
+public class WinConditionTests
+{
+    [Test]
+    public void PartiallyConnectedPuzzle_IsNotSolved()
+    {
+        // 3 pieces, 2 groups -> not solved
+        var groups = new Dictionary<int, PuzzleGroup>();
+        var g1 = new PuzzleGroup(0, 0);
+        g1.AddPiece(1);
+        var g2 = new PuzzleGroup(1, 2);
+        groups[0] = g1;
+        groups[1] = g2;
+
+        bool result = WinCondition.CheckWin(groups, 3);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void FullyConnectedPuzzle_IsSolved()
+    {
+        // 3 pieces, 1 group -> solved
+        var groups = new Dictionary<int, PuzzleGroup>();
+        var g1 = new PuzzleGroup(0, 0);
+        g1.AddPiece(1);
+        g1.AddPiece(2);
+        groups[0] = g1;
+
+        bool result = WinCondition.CheckWin(groups, 3);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void OneGroupButMissingPieces_IsNotSolved()
+    {
+        // 1 group but only 2 of 3 pieces
+        var groups = new Dictionary<int, PuzzleGroup>();
+        var g1 = new PuzzleGroup(0, 0);
+        g1.AddPiece(1);
+        groups[0] = g1;
+
+        bool result = WinCondition.CheckWin(groups, 3);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void OnPuzzleSolved_EventFires_WhenWon()
+    {
+        bool eventFired = false;
+        WinCondition.OnPuzzleSolved += () => eventFired = true;
+
+        var groups = new Dictionary<int, PuzzleGroup>();
+        var g1 = new PuzzleGroup(0, 0);
+        g1.AddPiece(1);
+        groups[0] = g1;
+
+        WinCondition.CheckWin(groups, 2);
+        Assert.IsTrue(eventFired);
+
+        WinCondition.OnPuzzleSolved -= () => eventFired = true;
+    }
+}


### PR DESCRIPTION
Closes #18

## What's changed
- `PuzzleGroup.cs` — tracks a set of connected piece IDs with merge support
- `WinCondition.cs` — checks win state using group count + piece count (not visual position); fires `OnPuzzleSolved` event on completion
- `GameStateManager.cs` — `StartNewGame` initializes each piece in its own group; `OnPiecesConnected` merges groups on snap and triggers win check

## Tests
Added `Assets/Tests/EditMode/WinConditionTests.cs` covering:
- Partially connected puzzle is NOT solved
- Fully connected puzzle IS solved
- One group with missing pieces is NOT solved
- `OnPuzzleSolved` event fires correctly on win