### PR TITLE
Finished Issue Implement Group System

### DIFF
--- a/Assets/Scripts/Puzzle/ConnectionSystem.cs
+++ b/Assets/Scripts/Puzzle/ConnectionSystem.cs
@@ -3,10 +3,16 @@ using UnityEngine;
 
 public class ConnectionSystem
 {
+    private GroupSystem groups;
+    public ConnectionSystem(GroupSystem groupSystem)
+    {
+        groups = groupSystem;
+    }
     public class PieceConnection
     {
         public int PieceAId;
         public int PieceBId;
+
         public PieceDirection Direction;
 
         public PieceConnection(int aId, int bId, PieceDirection direction)
@@ -20,6 +26,7 @@ public class ConnectionSystem
         {
             return (PieceAId == aId && PieceBId == bId) || (PieceAId == bId && PieceBId == aId);
         }
+
     }
     
     private List<PieceConnection> connections = new List<PieceConnection>();
@@ -53,6 +60,12 @@ public class ConnectionSystem
         {
             return;
         }
+
+        if(a.GroupId != b.GroupId)
+        {
+            groups.MergeGroups(a, b);
+        }
+
 
         PieceDirection direction = neighbors.GetRelativeDirection(a, b);
 

--- a/Assets/Scripts/Puzzle/ConnectionSystem.cs.meta
+++ b/Assets/Scripts/Puzzle/ConnectionSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 883e88d0747b6f642b164274a9b9e35e

--- a/Assets/Scripts/Puzzle/GroupSystem.cs
+++ b/Assets/Scripts/Puzzle/GroupSystem.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GroupSystem
+{
+    private Dictionary<int, List<PieceData>> groups = new Dictionary<int, List<PieceData>>();
+   
+    public void Initialize(List<PieceData> pieces)
+    {
+        groups.Clear();
+        foreach(var piece in pieces)
+        {
+            groups[piece.GroupId] = new List<PieceData> {piece};
+        }
+    }
+
+    public List<PieceData> GetGroup(PieceData piece)
+    {
+        if (groups.ContainsKey(piece.GroupId))
+        {
+            return groups[piece.GroupId];
+        }
+
+        return null;
+    }
+    
+    public List<PieceData> GetGroupMembers(int groupId)
+    {
+        if (groups.ContainsKey(groupId))
+        {
+            return groups[groupId];
+        }
+
+        return null;
+    }
+
+    public void MergeGroups(PieceData a, PieceData b)
+    {
+        var groupAId = a.GroupId;
+        var groupBId = b.GroupId;
+
+        if(groupAId == groupBId)
+        {
+            return;
+        }
+
+        List<PieceData> groupA = groups[groupAId];
+        List<PieceData> groupB = groups[groupBId];
+
+        foreach(var piece in groupB)
+        {
+            piece.GroupId = groupAId;
+            groupA.Add(piece);
+        }
+
+        groups.Remove(groupBId);
+    }
+
+
+}

--- a/Assets/Scripts/Puzzle/GroupSystem.cs.meta
+++ b/Assets/Scripts/Puzzle/GroupSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2c650b0dda28b84096b9e5e285f08b2

--- a/Assets/Scripts/Puzzle/PieceData.cs
+++ b/Assets/Scripts/Puzzle/PieceData.cs
@@ -6,6 +6,7 @@ public class PieceData
     public int Id { get; set; }
     public int Row { get; set; }
     public int Column { get; set; }
+    public int GroupId { get; set; }
 
     public EdgeType TopEdge { get; set; }
     public EdgeType RightEdge { get; set; }
@@ -15,11 +16,13 @@ public class PieceData
     public Vector2 Position { get; set; }
     public float Rotation { get; set; }
 
-    public PieceData(int id, int row, int column)
+
+    public PieceData(int id, int row, int column, int groupId)
     {
         Id = id;
         Row = row;
         Column = column;
+        GroupId = groupId;
 
         TopEdge = EdgeType.Flat;
         RightEdge = EdgeType.Flat;

--- a/Assets/Scripts/Puzzle/PuzzleGenerator.cs
+++ b/Assets/Scripts/Puzzle/PuzzleGenerator.cs
@@ -43,7 +43,7 @@ public class PuzzleGenerator
         {
             for(int column = 1; column <= columns; column++)
             {
-                PieceData piece = new PieceData(idNumber, row, column);
+                PieceData piece = new PieceData(idNumber, row, column, idNumber);
 
                 //ASSIGNING FLAT EDGES
                 if(row == 1){ piece.TopEdge = EdgeType.Flat; }


### PR DESCRIPTION
Added GroupSystem class

Other Classes Changed:
- PieceData: added a public int GroupId (w/getter and setter) and added it as a parameter to PieceData constructor

- PuzzleGenerator: assigned each piece a groupId starting at 0 and increasing by 1 for each piece (just used the same idNumber variable for this)

- ConnectionSystem: added a constructor for ConnectionSystem that takes in a GroupSystem object, this allows the same group list to be used in the connections. in the AddConnection method, called the MergeGroups method on the two pieces
NOTE: I’m not sure where we are gonna generate the puzzle, but wherever that is, after we generate the puzzle when also need to call the GroupSystem Initialize() method and the ConnectionSystem(GroupSystem) constructor for everything to work
