### PR TITLE
Improved on the Main Scene

### DIFF
--- a/Assets/Scripts/Managers/InteractionManager.cs
+++ b/Assets/Scripts/Managers/InteractionManager.cs
@@ -6,17 +6,23 @@ public class InteractionManager : MonoBehaviour
     [Header("Script Connections")]
     public SnappingManager snapManager;
 
-    [Header("Drag")]
+    [Header("Drag Settings")]
     [SerializeField] private float dragSmoothTime = 0.08f;
+
+    [Header("Zoom Settings")]
+    [SerializeField] private float minZoom = 2f;
+    [SerializeField] private float maxZoom = 15f;
+    [SerializeField] private float zoomSpeed = 0.02f; // smaller is typically better here
 
     private Camera gameCamera;
     private Transform selection;
     private Vector3 offset;
     private Renderer render;
     private int order = 1;
-
     private Vector3 dragTargetPosition;
     private Vector3 dragVelocity;
+    private Vector3 origin;
+    private bool isPanning = false;
   
     void Start()
     {
@@ -30,23 +36,39 @@ public class InteractionManager : MonoBehaviour
         }
 
         var leftButton = Mouse.current.leftButton;
+        var scrollY = Mouse.current.scroll.ReadValue().y;
         Vector3 mousePosition = gameCamera.ScreenToWorldPoint(Mouse.current.position.ReadValue());
         mousePosition.z = 0f;
+
+        if (Mathf.Abs(scrollY) > 0.01f)
+        {
+            ZoomCamera(scrollY);
+        }
 
         if (leftButton.wasPressedThisFrame)
         {
             TryPickup(mousePosition);
-        }
 
-        if (leftButton.isPressed && selection != null && render != null)
+            if (selection == null)
+            {
+                isPanning = true;
+                origin = mousePosition;
+            }
+        }
+        else if (leftButton.isPressed)
         {
-            Vector3 movement = mousePosition + offset;
-            dragTargetPosition = ScreenBoundaries(movement);
-
-            selection.position = Vector3.SmoothDamp(selection.position, dragTargetPosition, ref dragVelocity, dragSmoothTime);
+            if (selection != null && render != null) 
+            {
+                Vector3 movement = mousePosition + offset;
+                dragTargetPosition = ScreenBoundaries(movement);
+                selection.position = Vector3.SmoothDamp(selection.position, dragTargetPosition, ref dragVelocity, dragSmoothTime);
+            }
+            else if (isPanning)
+            {
+                PanCamera(mousePosition);
+            }
         }
-
-        if (leftButton.wasReleasedThisFrame)
+        else if (leftButton.wasReleasedThisFrame)
         {
             if (selection != null && snapManager != null)
             {
@@ -56,6 +78,17 @@ public class InteractionManager : MonoBehaviour
 
             dragVelocity = Vector3.zero;
         }
+    }
+    private void ZoomCamera(float scrollY)
+    {
+        var zoomAmount = scrollY * zoomSpeed;
+        gameCamera.orthographicSize = Mathf.Clamp(gameCamera.orthographicSize - zoomAmount, minZoom, maxZoom);
+    }
+    private void PanCamera(Vector3 mousePosition)
+    {
+        var difference = origin - mousePosition;
+        difference.z = 0f;
+        gameCamera.transform.position += difference;
     }
     private RaycastHit2D GrabPiece(Vector3 mousePosition)
     {

--- a/Assets/Scripts/Managers/InteractionManager.cs
+++ b/Assets/Scripts/Managers/InteractionManager.cs
@@ -19,7 +19,6 @@ public class InteractionManager : MonoBehaviour
     [SerializeField] private Color boundaryColor = Color.red;
     [SerializeField] private float boundaryThickness = 0.15f;
 
-    private LineRenderer[] boundaryLines;
     private Camera gameCamera;
     private Transform selection;
     private Vector3 offset;
@@ -49,7 +48,7 @@ public class InteractionManager : MonoBehaviour
 
         if (Mathf.Abs(y) > 0.01f)
         {
-            ZoomCamera(y);
+            ZoomCamera(y, mousePosition);
         }
 
         if (leftButton.wasPressedThisFrame)
@@ -86,13 +85,23 @@ public class InteractionManager : MonoBehaviour
             dragVelocity = Vector3.zero;
         }
     }
-    private void ZoomCamera(float y)
+    private void ZoomCamera(float y, Vector3 mousePosition)
     {
-        var maxHeight = boundaries.y / 2f;
-        var maxWidth = (boundaries.x / 2f) / gameCamera.aspect;
+        var size = Mathf.Clamp(gameCamera.orthographicSize - (y * zoomSpeed), minZoom, Mathf.Min(maxZoom, boundaries.y / 2f, boundaries.x / 2f / gameCamera.aspect));
 
-        gameCamera.orthographicSize = Mathf.Clamp(gameCamera.orthographicSize - (y * zoomSpeed), minZoom, Mathf.Min(maxZoom, maxHeight, maxWidth));
-        CameraBoundaries();
+        if (Mathf.Approximately(gameCamera.orthographicSize, size)) 
+        {
+            return;
+        }
+
+        gameCamera.orthographicSize = size;
+
+        var mousePostZoom = gameCamera.ScreenToWorldPoint(Mouse.current.position.ReadValue());
+        mousePostZoom.z = 0f;
+
+        gameCamera.transform.position += (mousePosition - mousePostZoom);
+
+        CameraBoundaries();    
     }
     private void PanCamera(Vector3 mousePosition)
     {

--- a/Assets/Scripts/Managers/InteractionManager.cs
+++ b/Assets/Scripts/Managers/InteractionManager.cs
@@ -14,6 +14,9 @@ public class InteractionManager : MonoBehaviour
     [SerializeField] private float maxZoom = 15f;
     [SerializeField] private float zoomSpeed = 0.02f; // smaller is typically better here
 
+    [Header("Boundary Settings")]
+    public Vector2 boundaries = new Vector2(30f, 20f);
+
     private Camera gameCamera;
     private Transform selection;
     private Vector3 offset;
@@ -36,13 +39,13 @@ public class InteractionManager : MonoBehaviour
         }
 
         var leftButton = Mouse.current.leftButton;
-        var scrollY = Mouse.current.scroll.ReadValue().y;
+        var y = Mouse.current.scroll.ReadValue().y;
         Vector3 mousePosition = gameCamera.ScreenToWorldPoint(Mouse.current.position.ReadValue());
         mousePosition.z = 0f;
 
-        if (Mathf.Abs(scrollY) > 0.01f)
+        if (Mathf.Abs(y) > 0.01f)
         {
-            ZoomCamera(scrollY);
+            ZoomCamera(y);
         }
 
         if (leftButton.wasPressedThisFrame)
@@ -60,7 +63,7 @@ public class InteractionManager : MonoBehaviour
             if (selection != null && render != null) 
             {
                 Vector3 movement = mousePosition + offset;
-                dragTargetPosition = ScreenBoundaries(movement);
+                dragTargetPosition = WorldBoundaries(movement);
                 selection.position = Vector3.SmoothDamp(selection.position, dragTargetPosition, ref dragVelocity, dragSmoothTime);
             }
             else if (isPanning)
@@ -79,16 +82,20 @@ public class InteractionManager : MonoBehaviour
             dragVelocity = Vector3.zero;
         }
     }
-    private void ZoomCamera(float scrollY)
+    private void ZoomCamera(float y)
     {
-        var zoomAmount = scrollY * zoomSpeed;
-        gameCamera.orthographicSize = Mathf.Clamp(gameCamera.orthographicSize - zoomAmount, minZoom, maxZoom);
+        var maxHeight = boundaries.y / 2f;
+        var maxWidth = (boundaries.x / 2f) / gameCamera.aspect;
+
+        gameCamera.orthographicSize = Mathf.Clamp(gameCamera.orthographicSize - (y * zoomSpeed), minZoom, Mathf.Min(maxZoom, maxHeight, maxWidth));
+        CameraBoundaries();
     }
     private void PanCamera(Vector3 mousePosition)
     {
         var difference = origin - mousePosition;
         difference.z = 0f;
         gameCamera.transform.position += difference;
+        CameraBoundaries();
     }
     private RaycastHit2D GrabPiece(Vector3 mousePosition)
     {
@@ -134,20 +141,28 @@ public class InteractionManager : MonoBehaviour
             }
         }
     }
-    private Vector3 ScreenBoundaries(Vector3 movement)
+    private void CameraBoundaries()
     {
-        var screenHeight = gameCamera.orthographicSize;
-        var screenWidth = screenHeight * gameCamera.aspect;
+        var x = Mathf.Max(0, (boundaries.x / 2f) - (gameCamera.orthographicSize * gameCamera.aspect));
+        var y = Mathf.Max(0, (boundaries.y / 2f) - gameCamera.orthographicSize);
         var cameraPosition = gameCamera.transform.position;
-        var left = cameraPosition.x - screenWidth;
-        var right = cameraPosition.x + screenWidth;
-        var bottom = cameraPosition.y - screenHeight;
-        var top = cameraPosition.y + screenHeight;
+
+        cameraPosition.x = Mathf.Clamp(cameraPosition.x, -x, x);
+        cameraPosition.y = Mathf.Clamp(cameraPosition.y, -y, y);
+
+        gameCamera.transform.position = cameraPosition;
+    }
+    private Vector3 WorldBoundaries(Vector3 movement)
+    {
+        var left = -boundaries.x / 2f;
+        var right = boundaries.x / 2f;
+        var bottom = -boundaries.y / 2f;
+        var top = boundaries.y / 2f;
 
         movement.x = Mathf.Clamp(movement.x, left, right - render.bounds.size.x);
         movement.y = Mathf.Clamp(movement.y, bottom, top - render.bounds.size.y);
 
-        return movement;
+        return movement;    
     }
     private Transform GetRoot(Transform piece)
     {

--- a/Assets/Scripts/Managers/InteractionManager.cs
+++ b/Assets/Scripts/Managers/InteractionManager.cs
@@ -16,7 +16,10 @@ public class InteractionManager : MonoBehaviour
 
     [Header("Boundary Settings")]
     public Vector2 boundaries = new Vector2(30f, 20f);
+    [SerializeField] private Color boundaryColor = Color.red;
+    [SerializeField] private float boundaryThickness = 0.15f;
 
+    private LineRenderer[] boundaryLines;
     private Camera gameCamera;
     private Transform selection;
     private Vector3 offset;
@@ -30,6 +33,7 @@ public class InteractionManager : MonoBehaviour
     void Start()
     {
         gameCamera = Camera.main;
+        BoundaryLines();
     }
     void Update()
     {
@@ -97,26 +101,51 @@ public class InteractionManager : MonoBehaviour
         gameCamera.transform.position += difference;
         CameraBoundaries();
     }
+    private void BoundaryLines()
+    {
+        var x = boundaries.x / 2f;
+        var y = boundaries.y / 2f;
+        var lineObject = new GameObject("BoundaryBox");
+        var renderer = lineObject.AddComponent<LineRenderer>();
+
+        lineObject.transform.SetParent(transform); 
+        
+        renderer.material = new Material(Shader.Find("Sprites/Default")); 
+        renderer.startWidth = boundaryThickness;
+        renderer.endWidth = boundaryThickness;
+        renderer.sortingOrder = 500; 
+        renderer.startColor = boundaryColor;
+        renderer.endColor = boundaryColor;
+
+        renderer.positionCount = 4;
+        renderer.SetPositions(new Vector3[] 
+        { 
+            new Vector3(-x, -y, 0),
+            new Vector3(-x, y, 0),  
+            new Vector3(x, y, 0),  
+            new Vector3(x, -y, 0)   
+        });
+        
+        renderer.loop = true;    
+    }
     private RaycastHit2D GrabPiece(Vector3 mousePosition)
     {
-        var hitPieces = Physics2D.RaycastAll(mousePosition, Vector2.zero);
-        int highestOrder = int.MinValue;
-        var topPiece = new RaycastHit2D();
+        var pieces = Physics2D.RaycastAll(mousePosition, Vector2.zero);
+        int highest = int.MinValue;
+        var top = new RaycastHit2D();
 
-        foreach (var piece in hitPieces)
+        foreach (var piece in pieces)
         {
             if (piece.collider != null && piece.collider.CompareTag("Piece"))
             {
-                var render = piece.transform.GetComponent<Renderer>();
-
-                if (render != null && render.sortingOrder > highestOrder)
+                if (piece.transform.TryGetComponent(out Renderer render) && render.sortingOrder > highest)
                 {
-                    highestOrder = render.sortingOrder;
-                    topPiece = piece;
+                    highest = render.sortingOrder;
+                    top = piece;
                 }
             }
         }
-        return topPiece;
+        return top;
     }
     private void TryPickup(Vector3 mousePosition)
     {


### PR DESCRIPTION
Improved many things about the main scene:

- Made the timer better
- Purged the green background
- Added a play area that can be panned around
- Can zoom in and out based on the location of the mouse
- Boundaries are defined by red lines

Many variables (like the world boundaries, zoom speed, boundary lines, etc) can all be changed in the unity inspector. Scripts are attached to the game manager object.