### PR TITLE
Fixed reset button and piece misallignment

### DIFF
--- a/Assets/Scripts/Managers/GameStateManager.cs
+++ b/Assets/Scripts/Managers/GameStateManager.cs
@@ -134,10 +134,7 @@ public class GameStateManager : MonoBehaviour
     {
         Debug.Log("Game restarting.");
 
-        ResetWinScreen();
-
         currentState = State.Inactive;
-        image = null;
         elapsedTime = 0f;
         
         if (timer != null)
@@ -145,7 +142,56 @@ public class GameStateManager : MonoBehaviour
             timer.text = "00:00:00"; 
         }
 
+        ResetPuzzle();
+    }
+    public void ResetPuzzle()
+    {
+        if (image == null)
+        {
+            Debug.LogWarning("No image loaded.");
+            return;
+        }
+
+        if (hasWon)
+        {
+            Debug.Log("Resetting Win Screen");
+            ResetWinScreen();
+        }
+
         ClearPuzzle();
+        Debug.Log("Puzzle cleared.");
+
+        if (modeSelectionPanel != null)
+        {
+            modeSelectionPanel.SetActive(true);
+        }
+    }
+    public void RestartTimer()
+    {
+        if (image != null)
+        {
+            elapsedTime = 0f;
+            currentState = State.Active;
+            Debug.Log("Timer reset.");
+        }
+    }
+    private void ResetWinScreen()
+    {
+        hasWon = false;
+        winScreenPanel?.SetActive(false);
+        if (solvedImageDisplay != null)
+        {
+            solvedImageDisplay.texture = null;
+            solvedImageDisplay.gameObject.SetActive(false);
+        }
+        winMusicSource?.Stop();
+        if (confettiCannons != null)
+        {
+            foreach (ParticleSystem cannon in confettiCannons)
+            {
+                cannon?.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            }
+        }
     }
     public void GeneratePuzzleFromJSON(Texture loadedImage, List<PieceData> savedPieces, int rows, int columns, int generationSeed, float savedElapsedTime = 0f)
     {
@@ -439,26 +485,6 @@ public class GameStateManager : MonoBehaviour
             gameCamera.transform.position = to;
     }
 
-    public void ResetPuzzle()
-    {
-        if (image == null) 
-        {
-            Debug.LogWarning("No image loaded.");
-            return;
-        }
-
-        Debug.Log("Puzzle reset.");
-        modeSelectionPanel.SetActive(true);    
-    }
-    public void RestartTimer()
-    {
-        if (image != null)
-        {
-            elapsedTime = 0f;
-            currentState = State.Active;
-            Debug.Log("Timer reset.");
-        }
-    }
     public void Update()
     {
         // Anything that updates as the game plays should be put into here.
@@ -760,25 +786,6 @@ public class GameStateManager : MonoBehaviour
             winMusicSource.volume = 0f;
             winMusicSource.Play();
             StartCoroutine(FadeInWinMusic(4f));
-        }
-    }
-
-    private void ResetWinScreen()
-    {
-        hasWon = false;
-        winScreenPanel?.SetActive(false);
-        if (solvedImageDisplay != null)
-        {
-            solvedImageDisplay.texture = null;
-            solvedImageDisplay.gameObject.SetActive(false);
-        }
-        winMusicSource?.Stop();
-        if (confettiCannons != null)
-        {
-            foreach (ParticleSystem cannon in confettiCannons)
-            {
-                cannon?.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
-            }
         }
     }
 }

--- a/Assets/Scripts/Managers/SnappingManager.cs
+++ b/Assets/Scripts/Managers/SnappingManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class SnappingManager : MonoBehaviour
@@ -10,7 +11,7 @@ public class SnappingManager : MonoBehaviour
 
     [Header("Animation Settings")]
     public float snapSpeed = 0.25f; // the speed value of snapping
-    public AnimationCurve snapCurve = AnimationCurve.EaseInOut(0, 0, 1, 1); // the curve inside the inspector that controls the snapping speed
+    public AnimationCurve snapCurve = AnimationCurve.EaseInOut(0, 0, 1, 1); // the curve inside the inspector that controls the snapping curve
 
     [Header("Effects")]
     public ParticleSystem snapParticles;
@@ -71,7 +72,7 @@ public class SnappingManager : MonoBehaviour
                         pieceGroup.position = startWorldPosition;
 
                         var scanConnections = ScanConnections(pieceGroup, targetRoot, groupPiece, piece);
-                        StartCoroutine(Animate(pieceGroup, targetRoot, startWorldPosition, endWorldPosition, scanConnections));
+                        StartCoroutine(Animate(pieceGroup, targetRoot, startWorldPosition, endWorldPosition, pieceGroup.rotation, rotation, scanConnections));
 
                         Debug.Log($"Snapped Piece {groupPiece.Data.Id} to Piece {piece.Data.Id}");
 
@@ -128,7 +129,7 @@ public class SnappingManager : MonoBehaviour
                         pieceGroup.position = startWorldPosition;
 
                         var scanConnections = ScanConnections(pieceGroup, targetRoot, groupPiece, piece);
-                        StartCoroutine(Animate(pieceGroup, targetRoot, startWorldPosition, endWorldPosition, scanConnections));
+                        StartCoroutine(Animate(pieceGroup, targetRoot, startWorldPosition, endWorldPosition, pieceGroup.rotation, rotation, scanConnections));
 
                         Debug.Log($"Auto snapped Piece {groupPiece.Data.Id} to Piece {piece.Data.Id}");
 
@@ -164,7 +165,7 @@ public class SnappingManager : MonoBehaviour
         
         return scanConnections;
     }
-    private IEnumerator Animate(Transform pieceGroup, Transform targetRoot, Vector3 start, Vector3 end, List<SnapPairs> scanConnections)
+    private IEnumerator Animate(Transform pieceGroup, Transform targetRoot, Vector3 start, Vector3 end, Quaternion startRotation, Quaternion endRotation, List<SnapPairs> scanConnections)
     {
         float elapsedTime = 0f;
 
@@ -179,10 +180,12 @@ public class SnappingManager : MonoBehaviour
         {
             elapsedTime += Time.deltaTime;
             pieceGroup.position = Vector3.Lerp(start, end, snapCurve.Evaluate(elapsedTime / snapSpeed));
+            pieceGroup.rotation = Quaternion.Lerp(startRotation, endRotation, snapCurve.Evaluate(elapsedTime / snapSpeed));
             yield return null;
         }
 
         pieceGroup.position = end;
+        pieceGroup.rotation = endRotation;
 
         MergeGroups(pieceGroup, targetRoot);
 
@@ -308,5 +311,22 @@ public class SnappingManager : MonoBehaviour
         }
 
         sourceRoot.SetParent(targetRoot, true);
+
+        if (targetRoot.GetComponent<PuzzlePiece>() != null)
+        {
+            foreach (var piece in targetRoot.GetComponentsInChildren<PuzzlePiece>())
+            {
+                if (piece.transform == targetRoot)
+                {
+                    continue;
+                }
+
+                Vector3 position = (Vector2)piece.SolvedPosition - (Vector2)targetRoot.GetComponent<PuzzlePiece>().SolvedPosition;
+                position.z = piece.transform.localPosition.z;
+
+                piece.transform.localPosition = position;
+                piece.transform.localRotation = Quaternion.identity;
+            }
+        }
     }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -241,7 +241,7 @@
       }
     },
     "com.unity.test-framework.performance": {
-      "version": "3.3.0",
+      "version": "3.2.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
 m_EditorVersion: 6000.4.1f1
-m_EditorVersionWithRevision: 6000.4.1f1 (336a400b9ea2)
+m_EditorVersionWithRevision: 6000.4.1f1 (8535861f39e1)


### PR DESCRIPTION
Fixes #110 and #106. Reset button works again, and pieces now account for rotation, which was the issue with misalignment after explosion.