### PR TITLE
Fix to Prevent Snap Before Explosion

### DIFF
--- a/Assets/Scripts/Puzzle/SnapValidation.cs
+++ b/Assets/Scripts/Puzzle/SnapValidation.cs
@@ -16,6 +16,12 @@ public class SnapValidation
             return false;
         }
 
+        var game = new GameStateManager();
+        if (game.elapsedTime == 0f)
+        {
+           return false;
+        }
+
         PieceDirection direction = neighborDetection.GetRelativeDirection(a, b);
 
         EdgeType edgeA;


### PR DESCRIPTION
I used the elapsedTime variable to prevent any snaps before explosion.